### PR TITLE
Investigate uWSGI emperor.

### DIFF
--- a/project/templates/configs/cms.config.ini
+++ b/project/templates/configs/cms.config.ini
@@ -1,0 +1,13 @@
+[uwsgi]
+; app directory
+chdir = /var/praekelt/unicore-cms-django
+; virtualenv home
+home = /var/praekelt/python
+protocol = http
+threads = 10
+master = true
+env = DJANGO_SETTINGS_MODULE=project.{{settings_module}}
+module = project.wsgi:application
+# 15 minutes
+idle = 900
+die-on-idle = true

--- a/project/templates/configs/pyramid.ini
+++ b/project/templates/configs/pyramid.ini
@@ -5,10 +5,11 @@
 
 # We're using uWSGI + Emperor on-demand setup
 [uwsgi]
-protocol=http
+protocol = http
 threads = 10
 master = true
-idle = 10
+# 15 minutes
+idle = 900
 die-on-idle = true
 
 [app:cmsfrontend]

--- a/project/templates/configs/pyramid.ini
+++ b/project/templates/configs/pyramid.ini
@@ -3,6 +3,14 @@
 # http://docs.pylonsproject.org/projects/pyramid/en/1.5-branch/narr/environment.html
 ###
 
+# We're using uWSGI + Emperor on-demand setup
+[uwsgi]
+protocol=http
+threads = 10
+master = true
+idle = 10
+die-on-idle = true
+
 [app:cmsfrontend]
 use = egg:unicore-cms-{{ app_type }}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ python-social-auth
 Django-ostinato
 elastic-git
 unicore-cms
+uwsgi==2.0.8

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,1 +1,1 @@
-py.test --ds=test_settings --verbose --cov ./unicoremc unicoremc$1
+rm -rf project/.test_* && py.test --ds=test_settings --verbose --cov ./unicoremc unicoremc$1

--- a/unicoremc/manager.py
+++ b/unicoremc/manager.py
@@ -62,8 +62,6 @@ class ConfigManager(object):
         )
 
     def destroy(self, app_type, country):
-        os.remove(self.get_frontend_supervisor_path(app_type, country))
-        os.remove(self.get_cms_supervisor_path(app_type, country))
         os.remove(self.get_frontend_nginx_path(app_type, country))
         os.remove(self.get_cms_nginx_path(app_type, country))
 

--- a/unicoremc/manager.py
+++ b/unicoremc/manager.py
@@ -157,6 +157,12 @@ class SettingsManager(object):
             '%s.py' % (self.get_cms_settings_module(app_type, country),)
         )
 
+    def get_cms_config_path(self, app_type, country):
+        return os.path.join(
+            self.cms_settings_dir,
+            '%s.ini' % (self.get_cms_settings_module(app_type, country),)
+        )
+
     def destroy(self, app_type, country):
         os.remove(self.get_frontend_settings_path(app_type, country))
         os.remove(self.get_cms_settings_path(app_type, country))

--- a/unicoremc/manager.py
+++ b/unicoremc/manager.py
@@ -85,23 +85,6 @@ class ConfigManager(object):
         with open(filepath, 'w') as config_file:
             config_file.write(frontend_supervisor_content)
 
-    def write_cms_supervisor(self, app_type, country, project_version):
-        cms_supervisor_content = render_to_string(
-            'configs/cms.supervisor.conf', {
-                'app_type': app_type,
-                'country': country.lower(),
-                'project_version': project_version,
-                'socket_path': os.path.join(
-                    self.sockets_dir,
-                    'cms.%s.%s.socket' % (app_type, country.lower()))
-            }
-        )
-
-        filepath = self.get_cms_supervisor_path(app_type, country)
-
-        with open(filepath, 'w') as config_file:
-            config_file.write(cms_supervisor_content)
-
     def write_frontend_nginx(self, app_type, country):
         frontend_nginx_content = render_to_string(
             'configs/frontend.nginx.conf', {
@@ -162,13 +145,16 @@ class SettingsManager(object):
             }
         )
 
+    def get_cms_settings_module(self, app_type, country):
+        return '%(app_type)s_%(country)s_settings' % {
+            'app_type': app_type,
+            'country': country.lower(),
+        }
+
     def get_cms_settings_path(self, app_type, country):
         return os.path.join(
             self.cms_settings_dir,
-            '%(app_type)s_%(country)s_settings.py' % {
-                'app_type': app_type,
-                'country': country.lower(),
-            }
+            '%s.py' % (self.get_cms_settings_module(app_type, country),)
         )
 
     def destroy(self, app_type, country):
@@ -226,6 +212,18 @@ class SettingsManager(object):
 
         with open(filepath, 'w') as config_file:
             config_file.write(cms_settings_content)
+
+    def write_cms_config(self, app_type, country, clone_url, repo_path):
+        cms_config_content = render_to_string(
+            'configs/cms.config.ini', {
+                'cms_settings_dir': self.cms_settings_dir,
+                'settings_module': self.get_cms_settings_module(
+                    app_type, country)
+            })
+
+        filepath = self.get_cms_config_path(app_type, country)
+        with open(filepath, 'w') as config_file:
+            config_file.write(cms_config_content)
 
 
 class DbManager(object):

--- a/unicoremc/models.py
+++ b/unicoremc/models.py
@@ -248,6 +248,12 @@ class Project(models.Model):
             self.repo_url,
             self.repo_path()
         )
+        self.settings_manager.write_cms_config(
+            self.app_type,
+            self.country,
+            self.repo_url,
+            self.repo_path()
+        )
 
     def create_webhook(self, access_token):
         repo_name = constants.NEW_REPO_NAME_FORMAT % {

--- a/unicoremc/models.py
+++ b/unicoremc/models.py
@@ -228,13 +228,6 @@ class Project(models.Model):
         Repo.clone_from(self.repo_git_url, self.frontend_repo_path())
         self.sync_frontend_index()
 
-    def create_supervisor(self):
-        self.config_manager.write_frontend_supervisor(
-            self.app_type, self.country, self.project_version)
-
-        self.config_manager.write_cms_supervisor(
-            self.app_type, self.country, self.project_version)
-
     def create_nginx(self):
         self.config_manager.write_frontend_nginx(self.app_type, self.country)
         self.config_manager.write_cms_nginx(self.app_type, self.country)

--- a/unicoremc/states.py
+++ b/unicoremc/states.py
@@ -68,15 +68,15 @@ class WebhookCreated(State):
 
 class WorkspaceInitialized(State):
     verbose_name = 'Workspace initialized'
-    transitions = {'create_supervisor': 'supervisor_created'}
+    transitions = {'create_vassal': 'vassal_created'}
 
-    def create_supervisor(self, **kwargs):
+    def create_vassal(self, **kwargs):
         if self.instance:
-            self.instance.create_supervisor()
+            self.instance.create_vassal()
 
 
-class SupervisorCreated(State):
-    verbose_name = 'Supervisor created'
+class VassalCreated(State):
+    verbose_name = 'Vassal created'
     transitions = {'create_nginx': 'nginx_created'}
 
     def create_nginx(self, **kwargs):
@@ -150,7 +150,7 @@ class ProjectWorkflow(StateMachine):
         'repo_pushed': RepoPushed,
         'webhook_created': WebhookCreated,
         'workspace_initialized': WorkspaceInitialized,
-        'supervisor_created': SupervisorCreated,
+        'vassal_created': VassalCreated,
         'nginx_created': NginxCreated,
         'pyramid_settings_created': PyramidSettingsCreated,
         'cms_settings_created': CmsSettingsCreated,

--- a/unicoremc/states.py
+++ b/unicoremc/states.py
@@ -68,15 +68,6 @@ class WebhookCreated(State):
 
 class WorkspaceInitialized(State):
     verbose_name = 'Workspace initialized'
-    transitions = {'create_vassal': 'vassal_created'}
-
-    def create_vassal(self, **kwargs):
-        if self.instance:
-            self.instance.create_vassal()
-
-
-class VassalCreated(State):
-    verbose_name = 'Vassal created'
     transitions = {'create_nginx': 'nginx_created'}
 
     def create_nginx(self, **kwargs):
@@ -150,7 +141,6 @@ class ProjectWorkflow(StateMachine):
         'repo_pushed': RepoPushed,
         'webhook_created': WebhookCreated,
         'workspace_initialized': WorkspaceInitialized,
-        'vassal_created': VassalCreated,
         'nginx_created': NginxCreated,
         'pyramid_settings_created': PyramidSettingsCreated,
         'cms_settings_created': CmsSettingsCreated,

--- a/unicoremc/tests/test_config_manager.py
+++ b/unicoremc/tests/test_config_manager.py
@@ -8,59 +8,6 @@ from unicoremc.manager import ConfigManager
 
 class ConfigManagerTestCase(TestCase):
 
-    def test_write_frontend_supervisor_configs(self):
-        cm = ConfigManager()
-        cm.write_frontend_supervisor('ffl', 'za', 1)
-
-        frontend_supervisor_config_path = os.path.join(
-            settings.SUPERVISOR_CONFIGS_PATH,
-            'frontend_ffl_za.conf')
-
-        frontend_settings_path = os.path.join(
-            settings.FRONTEND_SETTINGS_OUTPUT_PATH,
-            'ffl.production.za.ini')
-
-        socket_path = os.path.join(
-            settings.SOCKETS_PATH,
-            'ffl.za.socket')
-        self.assertTrue(os.path.exists(frontend_supervisor_config_path))
-
-        with open(frontend_supervisor_config_path, "r") as config_file:
-            data = config_file.read()
-
-        self.addCleanup(lambda: os.remove(frontend_supervisor_config_path))
-
-        self.assertTrue('program:unicore_frontend_ffl_za' in data)
-        self.assertTrue(frontend_settings_path in data)
-        self.assertTrue('/var/praekelt/unicore-cms-ffl' in data)
-        self.assertTrue('unix:' + socket_path in data)
-        self.assertTrue("UNICORE_PROJECT_VERSION=1" in data)
-
-    def test_write_cms_supervisor_configs(self):
-        cm = ConfigManager()
-        cm.write_cms_supervisor('ffl', 'za', 1)
-
-        cms_supervisor_config_path = os.path.join(
-            settings.SUPERVISOR_CONFIGS_PATH,
-            'cms_ffl_za.conf')
-
-        socket_path = os.path.join(
-            settings.SOCKETS_PATH,
-            'cms.ffl.za.socket')
-
-        self.assertTrue(os.path.exists(cms_supervisor_config_path))
-
-        with open(cms_supervisor_config_path, "r") as config_file:
-            data = config_file.read()
-
-        self.addCleanup(lambda: os.remove(cms_supervisor_config_path))
-
-        self.assertTrue('program:unicore_cms_ffl_za' in data)
-        self.assertTrue('project.ffl_za_settings' in data)
-        self.assertTrue('/var/praekelt/unicore-cms-django' in data)
-        self.assertTrue(socket_path in data)
-        self.assertTrue("UNICORE_PROJECT_VERSION=1" in data)
-
     def test_write_frontend_nginx_configs(self):
         cm = ConfigManager()
         cm.write_frontend_nginx('ffl', 'za')

--- a/unicoremc/tests/test_project.py
+++ b/unicoremc/tests/test_project.py
@@ -276,57 +276,6 @@ class ProjectTestCase(UnicoremcTestCase):
             workspace.S(Page).count(), 1)
 
     @responses.activate
-    def test_create_supervisor_config(self):
-        self.mock_create_repo()
-        self.mock_create_webhook()
-
-        p = Project(
-            app_type='ffl',
-            base_repo_url=self.base_repo_sm.repo.git_dir,
-            country='ZA',
-            owner=self.user)
-        p.save()
-
-        pw = ProjectWorkflow(instance=p)
-        pw.take_action('create_repo', access_token='sample-token')
-        pw.take_action('clone_repo')
-        pw.take_action('create_remote')
-        pw.take_action('merge_remote')
-        pw.take_action('push_repo')
-        pw.take_action('create_webhook', access_token='sample-token')
-        pw.take_action('init_workspace')
-        pw.take_action('create_supervisor')
-
-        frontend_supervisor_config_path = os.path.join(
-            settings.SUPERVISOR_CONFIGS_PATH,
-            'frontend_ffl_za.conf')
-        cms_supervisor_config_path = os.path.join(
-            settings.SUPERVISOR_CONFIGS_PATH,
-            'cms_ffl_za.conf')
-
-        self.assertTrue(os.path.exists(frontend_supervisor_config_path))
-        self.assertTrue(os.path.exists(cms_supervisor_config_path))
-
-        with open(frontend_supervisor_config_path, "r") as config_file:
-            data = config_file.read()
-
-        self.assertTrue('program:unicore_frontend_ffl_za' in data)
-        self.assertTrue('ffl.production.za.ini' in data)
-        self.assertTrue('/var/praekelt/unicore-cms-ffl' in data)
-        self.assertTrue("UNICORE_PROJECT_VERSION=0" in data)
-
-        with open(cms_supervisor_config_path, "r") as config_file:
-            data = config_file.read()
-
-        self.assertTrue('program:unicore_cms_ffl_za' in data)
-        self.assertTrue('project.ffl_za_settings' in data)
-        self.assertTrue('/var/praekelt/unicore-cms-django' in data)
-        self.assertTrue("UNICORE_PROJECT_VERSION=0" in data)
-
-        self.addCleanup(lambda: shutil.rmtree(p.repo_path()))
-        self.addCleanup(lambda: shutil.rmtree(p.frontend_repo_path()))
-
-    @responses.activate
     def test_create_nginx_config(self):
         self.mock_create_repo()
         self.mock_create_webhook()
@@ -346,7 +295,6 @@ class ProjectTestCase(UnicoremcTestCase):
         pw.take_action('push_repo')
         pw.take_action('create_webhook', access_token='sample-token')
         pw.take_action('init_workspace')
-        pw.take_action('create_supervisor')
         pw.take_action('create_nginx')
 
         frontend_nginx_config_path = os.path.join(
@@ -400,7 +348,6 @@ class ProjectTestCase(UnicoremcTestCase):
         pw.take_action('push_repo')
         pw.take_action('create_webhook', access_token='sample-token')
         pw.take_action('init_workspace')
-        pw.take_action('create_supervisor')
         pw.take_action('create_nginx')
         pw.take_action('create_pyramid_settings')
 

--- a/unicoremc/tests/test_settings_manager.py
+++ b/unicoremc/tests/test_settings_manager.py
@@ -1,4 +1,5 @@
 import os
+from ConfigParser import ConfigParser
 
 from django.test import TestCase
 from django.conf import settings
@@ -63,3 +64,24 @@ class SettingsManagerTestCase(TestCase):
             "ELASTIC_GIT_INDEX_PREFIX = 'unicore_cms_ffl_za'" in data)
         self.assertTrue("/path/to/repo/ffl_za" in data)
         self.assertTrue('http://some.repo.com/.git' in data)
+
+    def test_write_cms_config(self):
+        sm = SettingsManager()
+        sm.write_cms_config(
+            'ffl', 'za', 'http://some.repo.com/.git',
+            '/path/to/repo/ffl_za/')
+
+        cms_config_path = os.path.join(
+            settings.CMS_SETTINGS_OUTPUT_PATH,
+            'ffl_za_settings.ini')
+
+        self.assertTrue(os.path.exists(cms_config_path))
+
+        cp = ConfigParser()
+        with open(cms_config_path, "r") as fp:
+            cp.readfp(fp)
+
+        self.assertEqual(
+            cp.get('uwsgi', 'env'),
+            'DJANGO_SETTINGS_MODULE=project.ffl_za_settings')
+        self.assertTrue(cp.get('uwsgi', 'idle'))

--- a/unicoremc/tests/test_states.py
+++ b/unicoremc/tests/test_states.py
@@ -78,7 +78,6 @@ class StatesTestCase(UnicoremcTestCase):
         pw.take_action('push_repo')
         pw.take_action('create_webhook', access_token='sample-token')
         pw.take_action('init_workspace')
-        pw.take_action('create_supervisor')
         pw.take_action('create_nginx')
         pw.take_action('create_pyramid_settings')
         pw.take_action('create_cms_settings')

--- a/unicoremc/tests/test_views.py
+++ b/unicoremc/tests/test_views.py
@@ -142,14 +142,6 @@ class ViewsTestCase(UnicoremcTestCase):
             settings.SUPERVISOR_CONFIGS_PATH,
             'cms_ffl_za.conf')
 
-        with open(frontend_supervisor_config_path, "r") as config_file:
-            data = config_file.read()
-        self.assertTrue("UNICORE_PROJECT_VERSION=0" in data)
-
-        with open(cms_supervisor_config_path, "r") as config_file:
-            data = config_file.read()
-        self.assertTrue("UNICORE_PROJECT_VERSION=0" in data)
-
         resp = self.client.post(
             reverse('advanced', args=[project.id]),
             {'available_languages': [1, 2]})
@@ -167,14 +159,6 @@ class ViewsTestCase(UnicoremcTestCase):
         self.assertTrue(
             "[(u'eng_UK', u'English'), "
             "(u'swa_TZ', u'Swahili')]" in data)
-
-        with open(frontend_supervisor_config_path, "r") as config_file:
-            data = config_file.read()
-        self.assertTrue("UNICORE_PROJECT_VERSION=1" in data)
-
-        with open(cms_supervisor_config_path, "r") as config_file:
-            data = config_file.read()
-        self.assertTrue("UNICORE_PROJECT_VERSION=1" in data)
 
     def test_view_only_on_homepage(self):
         resp = self.client.get(reverse('home'))

--- a/unicoremc/views.py
+++ b/unicoremc/views.py
@@ -48,7 +48,6 @@ class ProjectEditView(UpdateView):
 
         project = self.get_object()
         project.create_pyramid_settings()
-        project.create_supervisor()
         return response
 
 


### PR DESCRIPTION
While this likely is not a long term strategy, it may be useful to investigate regardless:

```
If you need to deploy a big number of apps on a single server, or a group of 
servers, the Emperor mode is just the ticket. It is a special uWSGI instance that 
will monitor specific events and will spawn/stop/reload instances (known as 
vassals, when managed by an Emperor) on demand.
```
