### PR TITLE
cms settings should be saved to django project folder

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -22,7 +22,7 @@ FRONTEND_REPO_PATH = abspath(REPO_WORKSPACE, 'frontend')
 CMS_REPO_PATH = abspath(REPO_WORKSPACE, 'cms')
 
 CONFIG_WORKSPACE = '.test_config_dir'
-CONFIGS_REPO_PATH = abspath('.test_config_dir')
+CONFIGS_REPO_PATH = abspath('.test_config_repo_dir')
 NGINX_CONFIGS_PATH = abspath(CONFIG_WORKSPACE, 'nginx')
 FRONTEND_SETTINGS_OUTPUT_PATH = abspath(
     CONFIG_WORKSPACE, 'frontend_settings')

--- a/test_settings.py
+++ b/test_settings.py
@@ -23,9 +23,9 @@ CMS_REPO_PATH = abspath(REPO_WORKSPACE, 'cms')
 
 CONFIG_WORKSPACE = '.test_config_dir'
 CONFIGS_REPO_PATH = abspath('.test_config_repo_dir')
-NGINX_CONFIGS_PATH = abspath(CONFIG_WORKSPACE, 'nginx')
+NGINX_CONFIGS_PATH = abspath(CONFIGS_REPO_PATH, 'nginx')
 FRONTEND_SETTINGS_OUTPUT_PATH = abspath(
-    CONFIG_WORKSPACE, 'frontend_settings')
+    CONFIGS_REPO_PATH, 'frontend_settings')
 CMS_SETTINGS_OUTPUT_PATH = abspath(CONFIG_WORKSPACE, 'cms_settings')
 
 FRONTEND_SOCKETS_PATH = abspath('.test_sockets_dir', 'frontend_sockets')

--- a/unicoremc/tests/test_nginx_manager.py
+++ b/unicoremc/tests/test_nginx_manager.py
@@ -14,9 +14,7 @@ class NginxManagerTestCase(UnicoremcTestCase):
 
         nm.write_frontend_nginx('ffl', 'za', 'some.domain.com')
 
-        frontend_nginx_config_path = os.path.join(
-            settings.NGINX_CONFIGS_PATH,
-            'frontend_ffl_za.conf')
+        frontend_nginx_config_path = nm.get_frontend_nginx_path('ffl', 'za')
 
         frontend_socket_path = os.path.join(
             settings.FRONTEND_SOCKETS_PATH,
@@ -43,9 +41,7 @@ class NginxManagerTestCase(UnicoremcTestCase):
         nm = self.get_nginx_manager()
         nm.write_frontend_nginx('ffl', 'za', 'some.domain.com')
 
-        frontend_nginx_config_path = os.path.join(
-            settings.NGINX_CONFIGS_PATH,
-            'frontend_ffl_za.conf')
+        frontend_nginx_config_path = nm.get_frontend_nginx_path('ffl', 'za')
 
         with open(frontend_nginx_config_path, "r") as config_file:
             data = config_file.read()
@@ -59,9 +55,7 @@ class NginxManagerTestCase(UnicoremcTestCase):
         nm = self.get_nginx_manager()
         nm.write_cms_nginx('ffl', 'za', 'cms.domain.com')
 
-        cms_nginx_config_path = os.path.join(
-            settings.NGINX_CONFIGS_PATH,
-            'cms_ffl_za.conf')
+        cms_nginx_config_path = nm.get_cms_nginx_path('ffl', 'za')
 
         cms_socket_path = os.path.join(
             settings.CMS_SOCKETS_PATH,
@@ -86,9 +80,7 @@ class NginxManagerTestCase(UnicoremcTestCase):
         nm = self.get_nginx_manager()
         nm.write_cms_nginx('ffl', 'za', 'cms.domain.com')
 
-        cms_nginx_config_path = os.path.join(
-            settings.NGINX_CONFIGS_PATH,
-            'cms_ffl_za.conf')
+        cms_nginx_config_path = nm.get_cms_nginx_path('ffl', 'za')
 
         cms_socket_path = os.path.join(
             settings.CMS_SOCKETS_PATH,


### PR DESCRIPTION
For the CMS, we need to write the django settings file to `unicore-cms-django/project/` so that Django can find it. Currently we're only writing to the configs repo which lives in the mission control project.
