### PR TITLE
Cloning a QA content repo in Prod leaves the thumbor old image urls in the new repo

### DIFF
--- a/unicoremc/managers/database.py
+++ b/unicoremc/managers/database.py
@@ -38,7 +38,7 @@ class DbManager(object):
         ]
         self.call_subprocess(args, env=env, cwd=self.unicore_cms_install_dir)
 
-    def init_db(self, app_type, country):
+    def init_db(self, app_type, country, push_to_git=False):
         env = {
             'DJANGO_SETTINGS_MODULE': 'project.%s' % self.get_deploy_name(
                 app_type, country)
@@ -50,4 +50,6 @@ class DbManager(object):
             'import_from_git',
             '--quiet',
         ]
+        if push_to_git:
+            args.append('--push')
         self.call_subprocess(args, env=env, cwd=self.unicore_cms_install_dir)

--- a/unicoremc/models.py
+++ b/unicoremc/models.py
@@ -511,7 +511,8 @@ class Project(models.Model):
 
     @standalone_only
     def init_db(self):
-        self.db_manager.init_db(self.app_type, self.country)
+        self.db_manager.init_db(
+            self.app_type, self.country, push_to_git=True)
 
     def create_marathon_app(self):
         self.initiate_create_marathon_app()

--- a/unicoremc/tests/test_db_manager.py
+++ b/unicoremc/tests/test_db_manager.py
@@ -43,6 +43,7 @@ class DbManagerTestCase(TestCase):
                 in args)
             self.assertTrue('import_from_git' in args)
             self.assertTrue('--quiet' in args)
+            self.assertFalse('--push' in args)
 
         cm = DbManager()
 

--- a/unicoremc/tests/test_states.py
+++ b/unicoremc/tests/test_states.py
@@ -58,6 +58,7 @@ class StatesTestCase(UnicoremcTestCase):
                 in args)
             self.assertTrue('import_from_git' in args)
             self.assertTrue('--quiet' in args)
+            self.assertTrue('--push' in args)
 
         self.mock_create_all()
 


### PR DESCRIPTION
The new images are updated in the CMS, but not pushed back into the new repository
